### PR TITLE
[bugfix / DEL-20 / #2] Explicitly Set selectedElement as null Once Operations Have Finished

### DIFF
--- a/app/index.ts
+++ b/app/index.ts
@@ -220,8 +220,9 @@ function makeInteractive(circle: SVGCircleElement): void {
     'mouseup', () => {
       if (!drag && selectedElement) {
         removeElement(selectedElement);
-        slider.input.value -= 1;
+        slider.input.value = points.length;
         updatePointsSlider();
+        selectedElement = null;
       }
     });
 }


### PR DESCRIPTION
* As selectedElement was never cleared once mouseup event handler was complete, it was persisting the deleted point in memory until it is referenced again
* Because it was in memory, this meant mousemove event handler could re-plot this, creating a phantom point that wouldn't be reflected in the Points slider, nor the Points array