### PR TITLE
[DEL-20 / #2, DEL-35 / #6] Smoothed-out Move and Delete Events, Created Tooltip for Interactive Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <br>
 
+## [1.1.3] - 26/06/2023
+
+### Added 
+- `dblclick` event listener to delete points, replacing single-click
+- A help tooltip at the top-right of the interactive view
+
+### Fixed
+- [DEL-20 / #2] Moved points were being released lower than intended
+
+### Changed
+- Moved `dark` and `light` CSS classes from within `button.flat` for increased re-usability
+
+<br>
+
 ## [1.1.2] - 27/05/2023
 
 ### Added

--- a/app/index.scss
+++ b/app/index.scss
@@ -129,6 +129,24 @@ body {
   background-color: $light-primary;
 }
 
+.dark {
+  color: $dark-text;
+  background: $dark-secondary;
+
+  &:hover {
+    background: $dark-tertiary;
+  }
+}
+
+.light {
+  color: $light-text;
+  background: $light-secondary;
+
+  &:hover {
+    background: $light-tertiary;
+  }
+}
+
 button.flat {
   border: 0;
   cursor: pointer;
@@ -138,25 +156,44 @@ button.flat {
   letter-spacing: 2px;
   width: 10rem;
 
-  &.dark {
-    color: $dark-text;
-    background: $dark-secondary;
-
-    &:hover {
-      background: $dark-tertiary;
-    }
-  }
-
-  &.light {
-    color: $light-text;
-    background: $light-secondary;
-
-    &:hover {
-      background: $light-tertiary;
-    }
-  }
 
   &#refresh {
     width: unset;
   }
+}
+
+.tooltip {
+  border-radius: 100px;
+  padding: 0.5rem 1.25rem 0.5rem 1.25rem;
+  margin-left: auto;
+  z-index: 2;
+  font-size: 1.25rem;
+
+}
+
+.tooltip .tooltiptext {
+  display: flex;
+
+  margin-right: 2.5rem;
+
+  visibility: hidden;
+  text-align: center;
+  border-radius: 6px;
+  left: 82.5%;
+  position: absolute;
+  z-index: 1;
+  font-size: initial;
+
+  ul {
+    padding-left: 10px !important;
+    padding-right: 10px !important;
+  }
+
+  &:hover {
+    background: $dark-secondary !important;
+  }
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
 }

--- a/app/index.ts
+++ b/app/index.ts
@@ -287,6 +287,7 @@ function deselectElement(): void {
     svg.main.removeEventListener('mousemove', moveElement);
     svg.main.removeEventListener('mouseup', deselectElement);
 
+    currentY -= MENU_HEIGHT_PX;
     points.push(new Point(currentX, currentY));
 
     removeElement(selectedElement);

--- a/app/index.ts
+++ b/app/index.ts
@@ -218,12 +218,14 @@ function makeInteractive(circle: SVGCircleElement): void {
 
   circle.addEventListener(
     'mouseup', () => {
-      if (!drag && selectedElement) {
-        removeElement(selectedElement);
-        slider.input.value = points.length;
-        updatePointsSlider();
-        selectedElement = null;
-      }
+      selectedElement = null;
+    });
+
+  circle.addEventListener(
+    'dblclick', (event) => {
+      removeElement(event.target as HTMLElement);
+      slider.input.value = points.length;
+      updatePointsSlider();
     });
 }
 

--- a/index.html
+++ b/index.html
@@ -26,6 +26,15 @@
         <label for="colour2">Colour Two</label>
         <input type="color" id="colour2">
       </div>
+      <div class="control-interactive tooltip dark">
+        ?
+        <span class="tooltiptext dark">
+          <ul>
+            <li>1. Double-click on a point to delete it</li>
+            <li>2. Click and drag to move points and rearrange the triangulation</li>
+          </ul>
+        </span>
+      </div>
     </div>
     <svg id="main" preserveAspectRatio="xMidYMid slice">
       <defs id="artistic-gradients">


### PR DESCRIPTION
[DEL-20 / #2]
* Smoothed out Move event by offsetting Y coordinate with height of control bar at the top of the screen
  * Please note that this will drop the Point where the mouse is, rather than leaving it where it was before releasing the mouse
* Smoothed out Delete event by using double click event instead of single click

[DEL-35 / #6]
* Created tooltip for interactive mode that appears when hovering over the ? in the top-right
  * The ? is not in the center of the circle - could I have some help with this please? @JRSmiffy

* `dark` and `light` CSS classes are now defined independently for increased reusability