### PR TITLE
[DEL-31 / #5] Added Toggle Mechanism for Displaying a Triangle's Circum-circle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <br>
 
+## [1.3.0] - 07/08/2023
+
+### Added
+- [DEL-31] Added toggle mechanism for displaying a triangle's circum-circle when clicking inside its body
+
+<br>
+
 ## [1.2.3] - 04/08/2023
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <br>
 
+[1.3.0]: https://github.com/JRSmiffy/delaunay/compare/1.2.3...1.3.0
 [1.2.3]: https://github.com/JRSmiffy/delaunay/compare/1.2.2...1.2.3
 [1.2.2]: https://github.com/JRSmiffy/delaunay/compare/1.2.1...1.2.2
 [1.2.1]: https://github.com/JRSmiffy/delaunay/compare/1.2.0...1.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - [DEL-31] Added toggle mechanism for displaying a triangle's circum-circle when clicking inside its body
+- Note for Windows developers for building this project
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -13,4 +13,6 @@ Delaunay Triangulation [Demo](https://jrsmiffy.github.io/delaunay/)
 
 ## Notes
 - 📦  `npm run build --prefix ./app`
+  - For Windows users, use Git Bash (or WSL) for building
+  - `jq` is not included with Git Bash, so you can try `curl -L -o /usr/bin/jq.exe https://github.com/stedolan/jq/releases/latest/download/jq-win64.exe` to add it
 - 🚀  `main branch is served by GitHub Pages`

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -25,6 +25,7 @@ export const svg: any = {
   background: document.getElementById('artistic-background'),
   points: document.getElementById('points'),
   triangles: document.getElementById('triangles'),
+  circumCircles: document.getElementById('circum-circles'),
   stop1: document.getElementById('stop1'),
   stop2: document.getElementById('stop2')
 }

--- a/app/index.scss
+++ b/app/index.scss
@@ -55,6 +55,16 @@ body {
   }
 }
 
+.triangle {
+  transition: 300ms;
+
+  &:hover {
+    cursor: pointer;
+    fill: $dark-tertiary;
+    transition: 300ms;
+  }
+}
+
 #colour-selection {
   display: flex;
   gap: .5rem;

--- a/app/index.ts
+++ b/app/index.ts
@@ -146,7 +146,7 @@ function renderTriangles(triangles: Triangle[]): void {
 
       let targetCirc = svg.circumCircles.children[circumCircId];
       if ('none' == targetCirc.style.display) {
-        targetCirc.style.display = ''
+        targetCirc.style.display = '';
       } else {
         targetCirc.style.display = 'none';
       }
@@ -187,25 +187,25 @@ function renderTriangles(triangles: Triangle[]): void {
   }
 }
 
-function createCircumCircleSVG(triangle: Triangle, index: number) {
+function createCircumCircleSVG(triangle: Triangle, index: number): void {
 
-  let pointA = triangle.pointA;
-  let pointB = triangle.pointB;
-  let pointC = triangle.pointC;
+  const pointA = triangle.pointA;
+  const pointB = triangle.pointB;
+  const pointC = triangle.pointC;
 
-  let circumCircle = new Circle();
-  let center = circumCircle.calculateCenter(pointA, pointB, pointC);
-  let radius = circumCircle.calculateRadius(triangle, center);
+  const circumCircle = new Circle();
+  const center = circumCircle.calculateCenter(pointA, pointB, pointC);
+  const radius = circumCircle.calculateRadius(triangle, center);
 
-  let circumSVG: SVGCircleElement = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+  const circumSVG: SVGCircleElement = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
 
-  circumSVG.setAttribute('cx', center.x.toString())
-  circumSVG.setAttribute('cy', center.y.toString())
-  circumSVG.setAttribute('r', radius.toString())
+  circumSVG.setAttribute('cx', center.x.toString());
+  circumSVG.setAttribute('cy', center.y.toString());
+  circumSVG.setAttribute('r', radius.toString());
   circumSVG.setAttribute('fill', 'transparent');
-  circumSVG.setAttribute('stroke', 'white')
+  circumSVG.setAttribute('stroke', 'white');
   circumSVG.setAttribute('id', `circum-circle-${index}`);
-  circumSVG.style.display = 'none'
+  circumSVG.style.display = 'none';
 
   svg.circumCircles.appendChild(circumSVG);
 }
@@ -237,7 +237,7 @@ function initInteractive(): void {
 }
 
 /** Update Number Of Points Slider Value */
-function updatePointsSlider() {
+function updatePointsSlider(): void {
   slider.thumb.innerHTML = slider.input.value;
 
   const position = (parseInt(slider.input.value) / parseInt(slider.input.max));
@@ -333,7 +333,7 @@ function moveElement(event: any): void {
 /** Deselect The Current Element Being Interacted With */
 function deselectElement(): void {
   if (selectedElement) {
-    selectedElement.setAttribute('pointer-events', 'all')
+    selectedElement.setAttribute('pointer-events', 'all');
     paramHistory += '||' + currentId + '|' + absX + '|' + absY;
 
     svg.main.removeEventListener('mousemove', moveElement);
@@ -369,7 +369,7 @@ function initArtistic(): void {
 function generateColour(triangle: Triangle): number[] {
   let xCoords = [triangle.pointA.x, triangle.pointB.x, triangle.pointC.x].sort();
 
-  let stopColour = (xCoords[0] / window.innerWidth) // 0 < x < 1
+  let stopColour = (xCoords[0] / window.innerWidth); // 0 < x < 1
   let colour: number[] = [];
 
   for (let i = 0; i < 3; i++) {

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
             <li>1. Double-click to delete points</li>
             <li>2. Click and drag to move points</li>
             <li>3. Drag slider to change number of points</li>
+            <li>4. Click on a triangle to display its circum-circle</li>
             <ul id="version-numbers"><!-- To be populated in JS --></ul>
           </ul>
         </span>
@@ -49,6 +50,7 @@
         </linearGradient>
       </defs>
       <rect id="artistic-background" class="hide" x="0" y="0" width="100%" height="100%" stroke="none" fill="url(#grad1)"></rect>
+      <g id="circum-circles"></g>
       <g id="triangles"></g>
       <g id="points"></g>
     </svg>


### PR DESCRIPTION
* When hovering over a triangle's body, it will be highlighted and cursor will change to `pointer`
* Clicking within a triangle body will toggle the display of said triangle's circum-circle
* Refreshing, deleting or moving points will clear circum-circle SVGs from the DOM before creating new ones

Circle is displayed after clicking (cannot show cursor with Windows Snipping Tool):
![image](https://github.com/JRSmiffy/delaunay/assets/42878077/db879ed7-3e5a-4599-a3fb-8703db50dba8)

It is possible to toggle all circles as active:
![image](https://github.com/JRSmiffy/delaunay/assets/42878077/8f52e772-e0b6-44d3-8321-36d88a314c17)

A new `li` has been added to inform the user of this function:
![image](https://github.com/JRSmiffy/delaunay/assets/42878077/f2c8f644-6ea7-48f0-a37f-3156a7fa2227)

