### PR TITLE
[DEL-46] Replaced bash script for resolving DEMO and LIB version consts with import of package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <br>
+## [1.3.1] - 10/08/2023
+
+### Changed
+- [DEL-46] Replaced bash script for building .js file with version consts with .ts that imports package.json
+- Updated README as the message for Windows devs no longer applies
+
+<br>
 
 ## [1.3.0] - 07/08/2023
 
@@ -114,6 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <br>
 
+[1.3.1]: https://github.com/JRSmiffy/delaunay/compare/1.3.0...1.3.1
 [1.3.0]: https://github.com/JRSmiffy/delaunay/compare/1.2.3...1.3.0
 [1.2.3]: https://github.com/JRSmiffy/delaunay/compare/1.2.2...1.2.3
 [1.2.2]: https://github.com/JRSmiffy/delaunay/compare/1.2.1...1.2.2

--- a/README.md
+++ b/README.md
@@ -13,6 +13,4 @@ Delaunay Triangulation [Demo](https://jrsmiffy.github.io/delaunay/)
 
 ## Notes
 - 📦  `npm run build --prefix ./app`
-  - For Windows users, use Git Bash (or WSL) for building
-  - `jq` is not included with Git Bash, so you can try `curl -L -o /usr/bin/jq.exe https://github.com/stedolan/jq/releases/latest/download/jq-win64.exe` to add it
 - 🚀  `main branch is served by GitHub Pages`

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -1,3 +1,13 @@
+
+import packageJSON from './package.json'
+
+export const LIB_VERSION = packageJSON
+    .dependencies
+    ["@jrsmiffy/delaunator"]
+    .replace('^', '');
+
+export const DEMO_VERSION = packageJSON.version
+
 export const GREEN: [number, number, number] = [80, 250, 123];
 export const ORANGE: [number, number, number] = [227, 138, 88];
 export const PURPLE: [number, number, number] = [208, 118, 196];

--- a/app/get-versions.sh
+++ b/app/get-versions.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# Grab delaunator library version from package.json
-LIB_VERSION=$(cat < package.json | jq -r '.dependencies."@jrsmiffy/delaunator"' | sed 's/\^//g')
-# Grab project version from package.json
-DEMO_VERSION=$(cat package.json | jq -r '.version' | sed 's/\^//g')
-# Insert versions as const strings into versions.ts
-node -p "'export const LIB_VERSION = \'${LIB_VERSION}\';\nexport const DEMO_VERSION = \'${DEMO_VERSION}\';'" > versions.ts

--- a/app/index.ts
+++ b/app/index.ts
@@ -1,8 +1,7 @@
 import { Delaunay } from '@jrsmiffy/delaunator/lib/delaunay';
 import { Point } from '@jrsmiffy/delaunator/lib/shapes/point';
 import { Triangle } from '@jrsmiffy/delaunator/lib/shapes/triangle';
-import {DEMO_VERSION, LIB_VERSION} from './versions';
-import { GREEN, ORANGE, PURPLE, body, controls, slider, svg, INIT_NUM_POINTS, MENU_HEIGHT_PX } from './constants';
+import { GREEN, ORANGE, PURPLE, body, controls, slider, svg, INIT_NUM_POINTS, MENU_HEIGHT_PX, DEMO_VERSION, LIB_VERSION } from './constants';
 import $ from 'jquery';
 import {Circle} from "@jrsmiffy/delaunator/lib/shapes/circle";
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "app",
-  "version": "1.2.5-SNAPSHOT",
+  "version": "1.3.1-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "app",
-      "version": "1.2.5-SNAPSHOT",
+      "version": "1.3.1-SNAPSHOT",
       "license": "ISC",
       "dependencies": {
         "@jrsmiffy/delaunator": "^1.4.3",

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "1.2.5-SNAPSHOT",
+  "version": "1.3.0-SNAPSHOT",
   "description": "",
   "main": "index.ts",
   "scripts": {

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "create-version-consts": "bash get-versions.sh",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "npm run create-version-consts && tsc && browserify ./index.js -o ../index.js && sass ./index.scss ../index.css",
+    "build": "tsc && browserify ./index.js -o ../index.js && sass ./index.scss ../index.css",
     "gh-build": "npm run build --base-href /"
   },
   "keywords": [],

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "1.3.0-SNAPSHOT",
+  "version": "1.3.1-SNAPSHOT",
   "description": "",
   "main": "index.ts",
   "scripts": {

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -35,7 +35,7 @@
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 
     /* JavaScript Support */


### PR DESCRIPTION
You will notice that package.json is included in the JS that is visible via the browser's debugger tool. In this case, it won't reveal anything dangerous, but if encrypted properties were to included then it would require us to produce a different solution.

I have associated this with DEL-46 for the obvious reason, though I don't think this is going to resolve the problem that the ticket has been created for.