### PR TITLE
[DEL-47] Set .triangle:hover colour transition to only apply when body.interactive is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <br>
 
+## [1.3.3] - 11/08/2023
+
+### Changed
+- [DEL-47] Styling for hovering over triangles, so that colour changing and clicking to show circumcircles only applies to interactive mode
+
+<br>
+
 ## [1.3.2] - 11/08/2023
 
 ### Changed
@@ -132,7 +139,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <br>
 
-[1.3.1]: https://github.com/JRSmiffy/delaunay/compare/1.3.1...1.3.2
+[1.3.3]: https://github.com/JRSmiffy/delaunay/compare/1.3.2...1.3.3
+[1.3.2]: https://github.com/JRSmiffy/delaunay/compare/1.3.1...1.3.2
 [1.3.1]: https://github.com/JRSmiffy/delaunay/compare/1.3.0...1.3.1
 [1.3.0]: https://github.com/JRSmiffy/delaunay/compare/1.2.3...1.3.0
 [1.2.3]: https://github.com/JRSmiffy/delaunay/compare/1.2.2...1.2.3

--- a/app/index.scss
+++ b/app/index.scss
@@ -57,12 +57,14 @@ body {
   }
 }
 
-.triangle {
-  transition: 300ms;
+body.interactive {
+  .triangle {
+    transition: 300ms;
 
-  &:hover {
-    cursor: pointer;
-    fill: rgba(80, 250, 123, 0.1);
+    &:hover {
+      cursor: pointer;
+      fill: rgba(80, 250, 123, 0.1);
+    }
   }
 }
 

--- a/app/index.ts
+++ b/app/index.ts
@@ -168,7 +168,8 @@ function renderTriangles(triangles: Triangle[]): void {
     pointC.y = triangle.pointC.y;
     tri.points.appendItem(pointC);
 
-    createCircumcircle(triangle, i);
+    if (interactive)
+        createCircumcircle(triangle, i);
 
     i++;
     if (!interactive) {


### PR DESCRIPTION
* Styles for hovering over triangles (i.e. colour changes and cursor appearance) only applies when `<body>` has `interactive` class applied
*  Circumcircles are also only generated when interactive mode is active